### PR TITLE
Fix test setup with node:util

### DIFF
--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,12 +1,11 @@
+// Must be defined before any imports
+const { TextEncoder, TextDecoder } = require('node:util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
 import '@testing-library/jest-dom';
-import { TextEncoder, TextDecoder } from 'util';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
-
-// Fix for TextEncoder/TextDecoder not defined
-const { TextEncoder: NodeTextEncoder, TextDecoder: NodeTextDecoder } = require('util');
-global.TextEncoder = NodeTextEncoder;
-global.TextDecoder = NodeTextDecoder;
 
 // Fix for URL not defined
 const { URL } = require('url');

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,8 @@ const createJestConfig = nextJest({
 });
 
 const customJestConfig = {
-  setupFilesAfterEnv: ['<rootDir>/__tests__/setup.ts'],
+  setupFiles: ['<rootDir>/__tests__/setup.ts'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',


### PR DESCRIPTION
## Changes

- Fix TextEncoder/TextDecoder issue by using node:util
- Move setup before any imports
- Update Jest config to use setupFiles

## Testing

Fixed the test setup issues with TextEncoder/TextDecoder. Tests should now run properly.

## Notes

The TextEncoder issue has been fixed by:
1. Moving TextEncoder/TextDecoder setup before any imports
2. Using node:util instead of util
3. Updating Jest config to use setupFiles instead of setupFilesAfterEnv